### PR TITLE
Vagrant Checks

### DIFF
--- a/vvv/build-me-vvv.sh
+++ b/vvv/build-me-vvv.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+
+# Make sure vagrant is installed
+if hash vagrant 2>/dev/null; then
+    echo -e "✔ Vagrant installed ($(vagrant --version))\n"
+else
+    echo -e "Vagrant not found."
+    echo -e "Download Vagrant at https://www.vagrantup.com/downloads.html and run again."
+    exit 1
+fi
+
 echo -e "If you are on windows then you need to install wsl"
 echo -e "https://docs.microsoft.com/en-us/windows/wsl/install-win10"
 echo -e "Please make sure you're connected to the internet with a good connection this will take a while"

--- a/vvv/build-me-vvv.sh
+++ b/vvv/build-me-vvv.sh
@@ -32,7 +32,15 @@ done
 
 echo -e "\nProvision vagrant machine i.e. vagrant up --provision?"
 select yn in "yes" "no"; do case $yn in
-  yes ) vagrant up --provision && break;;
+  yes )
+    vagrant up --provision
+    if [ $? -eq 0 ]; then
+        break;
+    else
+        echo "Vagrant provisioning failed or needs to run again."
+        echo "Exiting now."
+        exit 1
+    fi;;
   no ) break;;
   esac
 done


### PR DESCRIPTION
Happy to adjust the style, location, and approach based on what you want.

Here's my stab at checking that vagrant exists and that provision works before moving on.

This PR:

1. Checks for vagrant and exits early if the user needs to install it
2. Checks the exit code of `vagrant up --provision` because sometimes vagrant provision needs to run multiple times or perhaps fails.

I am guessing that we want to exit if provision returns a non-zero exit code.